### PR TITLE
Move decode logic into wrapper struct

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package kmsconfig
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -102,15 +101,7 @@ func (c *Config) Load() error {
 
 func (c Config) decryptSecureValue(key string, value string) (string, error) {
 	log.Printf("Encrypted config value found for '%s', decrypting", key)
-
-	decodedValue, err := base64.StdEncoding.DecodeString(value)
-
-	if err != nil {
-		log.Printf("Could not Base64 decode: '%s'", value)
-		return "", err
-	}
-
-	decryptedValue, err := c.KMSWrapper.Decrypt(decodedValue)
+	decryptedValue, err := c.KMSWrapper.Decrypt(value)
 
 	if err != nil {
 		log.Printf("Failed to decrypt '%s'", key)

--- a/kms_wrapper.go
+++ b/kms_wrapper.go
@@ -1,8 +1,10 @@
 package kmsconfig
 
 import (
+	"encoding/base64"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
+	"log"
 )
 
 type (
@@ -20,8 +22,15 @@ func NewKMSWrapper() KMSWrapper {
 }
 
 // Decrypt comment pending
-func (k KMSWrapper) Decrypt(ciphertextBlob []byte) (string, error) {
-	output, err := k.Client.Decrypt(k.decryptParmas(ciphertextBlob))
+func (k KMSWrapper) Decrypt(encodedCipherTextBlob string) (string, error) {
+	decodedValue, err := base64.StdEncoding.DecodeString(encodedCipherTextBlob)
+
+	if err != nil {
+		log.Printf("Could not Base64 decode: '%s'", encodedCipherTextBlob)
+		return "", err
+	}
+
+	output, err := k.Client.Decrypt(k.decryptParmas(decodedValue))
 
 	if err != nil {
 		return "", err
@@ -30,8 +39,8 @@ func (k KMSWrapper) Decrypt(ciphertextBlob []byte) (string, error) {
 	return string(output.Plaintext[:]), nil
 }
 
-func (k KMSWrapper) decryptParmas(ciphertextBlob []byte) *kms.DecryptInput {
+func (k KMSWrapper) decryptParmas(cipherTextBlob []byte) *kms.DecryptInput {
 	return &kms.DecryptInput{
-		CiphertextBlob: ciphertextBlob,
+		CiphertextBlob: cipherTextBlob,
 	}
 }


### PR DESCRIPTION
### Problem

The payload given back by `KMS` is `base64` encoded. The decoding happens in the private method in the `config` struct, this means we need to manually do this step if we're using `Decrypt` on the `KMSWrapper` struct.

### Solution

Move the decoding into the `Decrypt` method so config uses this and we then have the decoding in the `Decrypt` method.

### Notes

* https://trello.com/c/G7g2Xu7l/232-kc-move-base64-decode-into-decrypt-method